### PR TITLE
Close about dialog to see the actual interactive

### DIFF
--- a/interactive-tests/default.rb
+++ b/interactive-tests/default.rb
@@ -1,14 +1,5 @@
 # Test if model can be run at least for 0.5s without errors. Then it's reloaded and stopped (as some models
 # are automatically started in "onLoad" scripts, what would cause that screenshots would be always different).
-def visible
-  style = $test.driver.find_element(:css=>'.about-dialog').attribute("style")
-  if style.include?('block')
-    return true
-  else
-    return false
-  end
-
-end
 
 $test.driver.execute_script 'Embeddable.controller.on("modelLoaded.selenium-test", function() { script.stop(); });' \
                             'script.start();' \
@@ -24,10 +15,10 @@ end
 sleep 1.5
 $test.save_screenshot
 
-close_dialog_size = $test.driver.find_elements(:css=>'.about-dialog > .ui-dialog-titlebar > .ui-dialog-titlebar-close').size #checks to see if there is an about dialog
-if close_dialog_size > 0 && visible #some interactives have hidden about dialogs so have to check if they are visible
-    puts "about box is visible"
-  $test.driver.find_element(:css=>'.about-dialog > .ui-dialog-titlebar > .ui-dialog-titlebar-close').click
+# close_dialog_size = $test.driver.find_elements(:css=>'.about-dialog .ui-dialog-titlebar-close').size #checks to see if there is an about dialog
+# if close_dialog_size > 0 && ($test.driver.find_element(:css=>'.about-dialog').attribute("style").include?('block')) #some interactives have hidden about dialogs so have to check if they are visible
+if $test.check_about_dialog_is_present
+  $test.close_about_dialog
   sleep 1.5
   $test.save_screenshot
 end

--- a/interactive-tests/default.rb
+++ b/interactive-tests/default.rb
@@ -24,9 +24,8 @@ end
 sleep 1.5
 $test.save_screenshot
 
-about_dialog = {:css=>'.about-dialog > .ui-dialog-titlebar'}
-close_dialog_size = $test.driver.find_elements(:css=>'.about-dialog > .ui-dialog-titlebar > .ui-dialog-titlebar-close').size
-if close_dialog_size > 0 && visible
+close_dialog_size = $test.driver.find_elements(:css=>'.about-dialog > .ui-dialog-titlebar > .ui-dialog-titlebar-close').size #checks to see if there is an about dialog
+if close_dialog_size > 0 && visible #some interactives have hidden about dialogs so have to check if they are visible
     puts "about box is visible"
   $test.driver.find_element(:css=>'.about-dialog > .ui-dialog-titlebar > .ui-dialog-titlebar-close').click
   sleep 1.5

--- a/interactive-tests/default.rb
+++ b/interactive-tests/default.rb
@@ -15,9 +15,7 @@ end
 sleep 1.5
 $test.save_screenshot
 
-# close_dialog_size = $test.driver.find_elements(:css=>'.about-dialog .ui-dialog-titlebar-close').size #checks to see if there is an about dialog
-# if close_dialog_size > 0 && ($test.driver.find_element(:css=>'.about-dialog').attribute("style").include?('block')) #some interactives have hidden about dialogs so have to check if they are visible
-if $test.check_about_dialog_is_present
+if $test.check_about_dialog_is_present  #some interactives have hidden about dialogs so have to check if they are visible
   $test.close_about_dialog
   sleep 1.5
   $test.save_screenshot

--- a/interactive-tests/default.rb
+++ b/interactive-tests/default.rb
@@ -1,5 +1,15 @@
 # Test if model can be run at least for 0.5s without errors. Then it's reloaded and stopped (as some models
 # are automatically started in "onLoad" scripts, what would cause that screenshots would be always different).
+def visible
+  style = $test.driver.find_element(:css=>'.about-dialog').attribute("style")
+  if style.include?('block')
+    return true
+  else
+    return false
+  end
+
+end
+
 $test.driver.execute_script 'Embeddable.controller.on("modelLoaded.selenium-test", function() { script.stop(); });' \
                             'script.start();' \
                             'setTimeout(function() { script.reloadModel(); }, 500);'
@@ -13,3 +23,12 @@ rescue Selenium::WebDriver::Error::NoSuchElementError
 end
 sleep 1.5
 $test.save_screenshot
+
+about_dialog = {:css=>'.about-dialog > .ui-dialog-titlebar'}
+close_dialog_size = $test.driver.find_elements(:css=>'.about-dialog > .ui-dialog-titlebar > .ui-dialog-titlebar-close').size
+if close_dialog_size > 0 && visible
+    puts "about box is visible"
+  $test.driver.find_element(:css=>'.about-dialog > .ui-dialog-titlebar > .ui-dialog-titlebar-close').click
+  sleep 1.5
+  $test.save_screenshot
+end

--- a/interactive-tests/interactives_interactions_targetFreePlay.rb
+++ b/interactive-tests/interactives_interactions_targetFreePlay.rb
@@ -1,6 +1,8 @@
 # Run basic test first.
 load 'interactive-tests/default.rb', true
 
+$test.click_element('#main-help-icon')
+$test.save_screenshot
 $test.select_radio_option('select-level', 1)
 sleep 1
 $test.save_screenshot

--- a/interactive-tests/interactives_interactions_targetFreePlay.rb
+++ b/interactive-tests/interactives_interactions_targetFreePlay.rb
@@ -1,7 +1,7 @@
 # Run basic test first.
 load 'interactive-tests/default.rb', true
-$test.click_element('#main-help-icon')
-$test.save_screenshot
+# $test.click_element('#main-help-icon')
+# $test.save_screenshot
 $test.select_radio_option('select-level', 1)
 sleep 1
 $test.save_screenshot

--- a/interactive-tests/interactives_interactions_targetFreePlay.rb
+++ b/interactive-tests/interactives_interactions_targetFreePlay.rb
@@ -1,7 +1,6 @@
 # Run basic test first.
 load 'interactive-tests/default.rb', true
-# $test.click_element('#main-help-icon')
-# $test.save_screenshot
+
 $test.select_radio_option('select-level', 1)
 sleep 1
 $test.save_screenshot

--- a/interactive-tests/interactives_interactions_targetGameCharge.rb
+++ b/interactive-tests/interactives_interactions_targetGameCharge.rb
@@ -1,8 +1,6 @@
 # Run basic test first.
 load 'interactive-tests/default.rb', true
 
-# $test.close_about_dialog
-
 $test.driver.execute_script('script.set("object-a-charge", -2);')
 $test.driver.execute_script('script.set("object-b-charge", 1);')
 

--- a/interactive-tests/interactives_interactions_targetGameCharge.rb
+++ b/interactive-tests/interactives_interactions_targetGameCharge.rb
@@ -1,7 +1,7 @@
 # Run basic test first.
 load 'interactive-tests/default.rb', true
 
-$test.close_about_dialog
+# $test.close_about_dialog
 
 $test.driver.execute_script('script.set("object-a-charge", -2);')
 $test.driver.execute_script('script.set("object-b-charge", 1);')

--- a/interactive-tests/interactives_interactions_targetGameDist.rb
+++ b/interactive-tests/interactives_interactions_targetGameDist.rb
@@ -1,6 +1,8 @@
 # Run basic test first.
 load 'interactive-tests/default.rb', true
 
+$test.click_element('#main-help-icon')
+$test.save_screenshot
 $test.select_radio_option('select-level', 1)
 sleep 1
 $test.save_screenshot

--- a/interactive-tests/interactives_interactions_targetGameDist.rb
+++ b/interactive-tests/interactives_interactions_targetGameDist.rb
@@ -1,7 +1,7 @@
 # Run basic test first.
 load 'interactive-tests/default.rb', true
-$test.click_element('#main-help-icon')
-$test.save_screenshot
+# $test.click_element('#main-help-icon')
+# $test.save_screenshot
 $test.select_radio_option('select-level', 1)
 sleep 1
 $test.save_screenshot

--- a/interactive-tests/interactives_interactions_targetGameDist.rb
+++ b/interactive-tests/interactives_interactions_targetGameDist.rb
@@ -1,7 +1,6 @@
 # Run basic test first.
 load 'interactive-tests/default.rb', true
-# $test.click_element('#main-help-icon')
-# $test.save_screenshot
+
 $test.select_radio_option('select-level', 1)
 sleep 1
 $test.save_screenshot

--- a/lib/test_api.rb
+++ b/lib/test_api.rb
@@ -45,6 +45,11 @@ class TestAPI
     end
   end
 
+  def check_about_dialog_is_present
+    close_dialog_size = $test.driver.find_elements(:css=>'.about-dialog .ui-dialog-titlebar-close').size #checks to see if there is an about dialog
+    close_dialog_size > 0 && ($test.driver.find_element(:css=>'.about-dialog').attribute("style").include?('block'))? true: false
+  end
+
   def click_element(css_selector)
     case @browser
     when :iPad

--- a/lib/test_api.rb
+++ b/lib/test_api.rb
@@ -69,7 +69,7 @@ class TestAPI
 
   def open_pulldown(id)
     case @browser
-    when :iPad
+    when :iPad, :Android
       @driver.execute_script "$('##{id} select').data('selectBox-selectBoxIt').open();"
     else
       $test.driver.find_element(:css, "##{id} .selectboxit").click
@@ -79,7 +79,9 @@ class TestAPI
   def select_pulldown_option(id, option_idx)
     case @browser
     when :iPad, :Android
-      @driver.execute_script "$('##{id} select').data('selectBox-selectBoxIt').close().selectOption(#{option_idx});"
+      $test.driver.find_element(:css, "##{id}")
+      pulldown_list = $test.driver.find_elements(:css, "##{id} select option")
+      pulldown_list[option_idx].click
     else
       $test.driver.find_element(:css, "##{id} .selectboxit-options li:nth-child(#{option_idx + 1}) a").click
     end

--- a/lib/test_helper.rb
+++ b/lib/test_helper.rb
@@ -29,12 +29,13 @@ class TestHelper
       img = Magick::Image.read(screenshot_path).first
       # For some reason both iPad and Android sreenshots are rotated. -- 3/31/2017 Only Android screenshots are rotated
       if browser == :Android
-        img.rotate!(-90)
+        img.rotate!(90)
       end
       # Both iPad and Android screenshots contain top bar with clock, URL etc.
       # that could obfuscate the image comparison algorithm results.
-      top_margin = browser == :iPad ? 63 : 120
-      img.crop!(0, top_margin, img.columns, img.rows - top_margin)
+      top_margin = browser == :iPad ? 140 : 160
+      side_margin = browser == :Android ? 85 : 0
+      img.crop!(0, top_margin, img.columns-side_margin, img.rows - top_margin)
       img.write(screenshot_path)
     end
 


### PR DESCRIPTION
Added code to default.rb to close the About dialog and take another screenshot so interactive isn't hidden behind the dialog.
Had to remove the code for closing dialogs in the target interactives